### PR TITLE
docker-compose file optimization

### DIFF
--- a/alertmanager/config.yml
+++ b/alertmanager/config.yml
@@ -5,4 +5,4 @@ receivers:
 - name: 'alertmanager-bot'
   webhook_configs:
   - send_resolved: true
-    url: 'http://172.18.0.6:8080'
+    url: 'http://alertmanager-bot:8080'

--- a/docker-compose-alertmanager-bot.yml
+++ b/docker-compose-alertmanager-bot.yml
@@ -2,7 +2,6 @@ version: '2'
 services:
   prometheus:
     image: prom/prometheus
-    container_name: prometheus
     command:
     - --config.file=/etc/prometheus/prometheus.yml
     - --storage.tsdb.retention.size=1GB
@@ -10,14 +9,10 @@ services:
     - ./prometheus:/etc/prometheus:ro
     depends_on:
     - exporter
-    networks:
-      back:
-        ipv4_address: 172.18.0.4
     restart: always
 
   grafana:
     image: grafana/grafana
-    container_name: grafana
     ports:
       - "3000:3000"
     volumes:
@@ -26,17 +21,12 @@ services:
     - ./provisioning:/etc/grafana/provisioning
     depends_on:
     - prometheus
-    networks:
-      back:
-      front:
     restart: always
 
   exporter:
-    container_name: exporter
     build: mining-exporter
     volumes:
     - exporter_data:/prometheus-mining
-    network_mode: host
     environment:
       - RIGS=${RIGS}
     restart: always
@@ -45,9 +35,6 @@ services:
     image: prom/alertmanager
     volumes:
       - ./alertmanager/:/etc/alertmanager/:ro
-    networks:
-      back:
-        ipv4_address: 172.18.0.5
     restart: always
     command:
       - '--config.file=/etc/alertmanager/config.yml'
@@ -57,14 +44,9 @@ services:
 
   alertmanager-bot:
     image: metalmatze/alertmanager-bot:0.4.2
-    container_name: alertmanager-bot
-    networks:
-      back:
-        ipv4_address: 172.18.0.6
-      front:
     restart: always
     environment:
-      ALERTMANAGER_URL: http://172.18.0.5:9093
+      ALERTMANAGER_URL: http://alertmanager:9093
       STORE: bolt
       BOLT_PATH: /data/bot.db
       TEMPLATE_PATHS: /templates/default.tmpl
@@ -73,17 +55,6 @@ services:
     - ./alertmanager-bot.sh:/start.sh
     entrypoint:
     - /start.sh
-
-networks:
-  back:
-    driver: bridge
-    ipam:
-      driver: default
-      config:
-      - subnet: "172.18.0.0/24"
-        gateway: 172.18.0.1
-  front:
-    driver: bridge
 
 volumes:
   grafana_var_lib:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ version: '2'
 services:
   prometheus:
     image: prom/prometheus
-    container_name: prometheus
     command:
     - --config.file=/etc/prometheus/prometheus.yml
     - --storage.tsdb.retention.size=1GB
@@ -10,14 +9,10 @@ services:
     - ./prometheus:/etc/prometheus:ro
     depends_on:
     - exporter
-    networks:
-      back:
-        ipv4_address: 172.18.0.4
     restart: always
 
   grafana:
     image: grafana/grafana
-    container_name: grafana
     ports:
       - "3000:3000"
     volumes:
@@ -26,29 +21,14 @@ services:
     - ./provisioning:/etc/grafana/provisioning
     depends_on:
     - prometheus
-    networks:
-      back:
-      front:
     restart: always
 
   exporter:
     container_name: exporter
     build: mining-exporter
-    network_mode: host
     environment:
     - RIGS=${RIGS}
     restart: always
-
-networks:
-  back:
-    driver: bridge
-    ipam:
-      driver: default
-      config:
-      - subnet: "172.18.0.0/24"
-        gateway: 172.18.0.1
-  front:
-    driver: bridge
 
 volumes:
   grafana_var_lib:

--- a/mining-exporter/lighttpd.conf
+++ b/mining-exporter/lighttpd.conf
@@ -1,6 +1,6 @@
 server.modules = ("mod_cgi")
 server.document-root = "/prometheus-mining/cgi-bin"
-server.bind = "172.18.0.1"
+server.bind = "exporter"
 server.port = 8080
 server.max-keep-alive-idle = 15
 

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,7 +1,7 @@
 scrape_configs:
   - job_name: 'miner'
     static_configs:
-      - targets: ['172.18.0.1:8080']
+      - targets: ['exporter:8080']
 
 global:
   scrape_interval: 2m
@@ -12,7 +12,7 @@ alerting:
  alertmanagers:
    - static_configs:
      - targets:
-       - 172.18.0.5:9093
+       - alertmanager:9093
 
 rule_files:
   - "alert.rules"

--- a/provisioning/datasources/automatic.yml
+++ b/provisioning/datasources/automatic.yml
@@ -9,5 +9,5 @@ datasources:
     type: prometheus
     access: proxy
     isDefault: true
-    url: http://172.18.0.4:9090
+    url: http://prometheus:9090
     editable: true


### PR DESCRIPTION
Change the IP address of services for their hostnames.
Remove unnecessary networks: no need for two networks: the docker-compose default network is not accessible from the outside except the service exposes itself explicitly.