### PR TITLE
Bind lighttpd to all interfaces

### DIFF
--- a/mining-exporter/lighttpd.conf
+++ b/mining-exporter/lighttpd.conf
@@ -1,6 +1,5 @@
 server.modules = ("mod_cgi")
 server.document-root = "/prometheus-mining/cgi-bin"
-server.bind = "exporter"
 server.port = 8080
 server.max-keep-alive-idle = 15
 


### PR DESCRIPTION
I was running the exporter through Traefik (a reverse proxy), but it couldn't connect due to binding only to the "exporter" interface.

This PR removes the specific binding and leaves the default (binding to all interfaces)